### PR TITLE
Server crash due to lack of error handling

### DIFF
--- a/server-plugin/plugin.js
+++ b/server-plugin/plugin.js
@@ -79,8 +79,11 @@ module.exports = function startup(options, imports, register) {
                     return;
                 }
                 timeouts[id] = setTimeout(function() {
-                    connections[id].ee.emit("disconnect", reason);
-                    delete connections[id];
+                    // the connection might not exist on the server
+                    if (connections[id]) {
+                        connections[id].ee.emit("disconnect", reason);
+                        delete connections[id];
+                    }
                     id = false;
                 }, RECONNECT_TIMEOUT);
                 connections[id].ee.emit("away");


### PR DESCRIPTION
In the cloud9 logs

```
Cannot read property 'ee' of undefined TypeError: Cannot read property 'ee' of undefined
    at Object._onTimeout (/home/ubuntu/c9/node_modules/cloud9/node_modules/smith.io/server-plugin/plugin.js:82:36)
    at Timer.ontimeout (timers.js:94:19)
Server Lifecycle destroy
RunVM Lifecycle destroy
RunVM Lifecycle destroy
RunVM Lifecycle destroy
Remote disconnected, reconnecting in 500ms
Warning: Permanently added '107.21.247.175' (ECDSA) to the list of known hosts.
```
