### PR TITLE
Expose the smith transport and bump the smith minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "pm": "npm",
     "dependencies": {
-        "smith": "https://github.com/c9/smith/tarball/packing-fix",
+        "smith": "~0.1.17",
         "msgpack-js-browser": "~0.1.3",
         "engine.io": "https://github.com/c9/engine.io/tarball/5f6fb9e32caed4f3edbb9f8536a13a20435d3d69"
     },

--- a/server-plugin/plugin.js
+++ b/server-plugin/plugin.js
@@ -99,6 +99,7 @@ module.exports = function startup(options, imports, register) {
                         };
                         gee.emit("connect", {
                             id: id,
+                            transport: connections[id].transport,
                             on: connections[id].ee.on.bind(connections[id].ee),
                             once: connections[id].ee.once.bind(connections[id].ee),
                             send: function(message) {


### PR DESCRIPTION
This is to replace the vfs-in-browser PR.  Instead of baking vfs into smith.io, I'm just exposing the required bits to use it externally.
